### PR TITLE
Allowing 'washington' too

### DIFF
--- a/lib/active_tax/states/wa.rb
+++ b/lib/active_tax/states/wa.rb
@@ -38,5 +38,6 @@ module ActiveTax
         r
       end
     end
+    WASHINGTON = WA unless defined?(WASHINGTON)
   end
 end

--- a/lib/active_tax/tax.rb
+++ b/lib/active_tax/tax.rb
@@ -15,7 +15,7 @@ module ActiveTax
       self.state = address[:state] if address[:state]
 
       case self.state.upcase
-      when "WA"
+      when "WA", "WASHINGTON"
         self.api_class = States::WA
       else
         raise StandardError, "API for #{self.state.upcase} not yet implemented in ActiveTax."


### PR DESCRIPTION
Allows you to pass in "washington", not just "wa".
