### PR TITLE
Raise exception when no address in Washington State

### DIFF
--- a/lib/active_tax/states/wa.rb
+++ b/lib/active_tax/states/wa.rb
@@ -4,6 +4,8 @@ module ActiveTax
       API_URI = "http://webgis.dor.wa.gov/webapi/AddressRates.aspx/text"
 
       def self.tax(address={})
+        raise StandardError.new("You must provide a street address to access Washington State sales tax rates. #{address.inspect}") if !address[:address]
+
         # http://webgis.dor.wa.gov/webapi/AddressRates.aspx/text?output=text&addr=6500+Linderson+Way&city=Tumwater&zip=98501
         params = {
           output: "text",

--- a/lib/active_tax/tax.rb
+++ b/lib/active_tax/tax.rb
@@ -42,9 +42,5 @@ module ActiveTax
       else raise StandardError, "API for #{self.state.upcase} not yet implemented in ActiveTax."
       end
     end
-
-    def api_data
-
-    end
   end
 end

--- a/test/test_tax.rb
+++ b/test/test_tax.rb
@@ -33,6 +33,18 @@ class TestTax < Minitest::Test
 
     assert_in_delta tax.rate * 100.0, 8.2, 2.5 # 8.2%, within about 2.5%
     assert_equal tax.location_code, "3406"
-    assert_equal tax.result_code, "0"
+    assert_equal tax.result_code, "2"
+  end
+
+  def test_missing_info
+    tax = ActiveTax::Tax.new({
+      city: "Seattle",
+      zip: "98102",
+      state: "WA"
+    })
+
+    assert_raises StandardError do
+      tax.result_code
+    end
   end
 end


### PR DESCRIPTION
Per issue #8 filed by @mamstergrub , this raises an exception if no address was provided.